### PR TITLE
Actualizo dependencias en requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.8
+SQLAlchemy==2.0.38
+pydantic==2.10.6
+uvicorn==0.34.0


### PR DESCRIPTION
Se creó el archivo `requirements.txt` para listar las librerías necesarias junto con sus versiones. Esto ayuda a estandarizar las dependencias del proyecto y a evitar incompatibilidades entre versiones de paquetes.